### PR TITLE
Added check name for ci job for using within branch protection rule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ defaults:
 
 jobs:
   build:
+    name: ci-build # pinning check name so if workflow file name changes the check is still enforced
     runs-on: ubuntu-latest
 
     services:


### PR DESCRIPTION
- adding stable check name for ci job (build.yml) to add as check in branch protection rule